### PR TITLE
Update docstring for get_adjacent_tracks

### DIFF
--- a/Native Instruments/script/NILA_UI/NILA_mixer.py
+++ b/Native Instruments/script/NILA_UI/NILA_mixer.py
@@ -27,9 +27,10 @@ def update_mixer_order(force=False):
 	ordered_tracks_cache = [t[1] for t in tracks]
 
 def get_adjacent_tracks(current_track):
-	"""
-	Returns up to MAX_KNOBS visually adjacent mixer tracks.
-	"""
+        """
+        Returns the visually adjacent mixer tracks.
+        The number of tracks returned equals c.max_knobs.
+        """
 	if current_track not in ordered_tracks_cache:
 		update_mixer_order()
 


### PR DESCRIPTION
## Summary
- clarify the number of mixer tracks returned by `get_adjacent_tracks`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877c65a1aec8323ad856a8cb64df00b