### PR TITLE
Fix MIDI_Script_Version duplicate

### DIFF
--- a/Native Instruments/script/device_setup/constants.py
+++ b/Native Instruments/script/device_setup/constants.py
@@ -152,7 +152,8 @@ stereo_sep = 0.25
 oled_vol_bar_scaling = 0.86
 
 # ==== MIDI, ENCODER, AND KNOB VALUES ====
-MIDI_Script_Version = 23
+# MIDI_Script_Version is defined near the start of this file with value 38.
+# Remove the duplicate definition that previously overwrote that value.
 midi_cc_max = 127
 midi_pitch_bend_center = 8192
 midi_pitch_bend_max = 16383


### PR DESCRIPTION
## Summary
- remove duplicate `MIDI_Script_Version` so the required version remains `38`

## Testing
- `python3 -m py_compile 'Native Instruments/script/device_setup/constants.py'`
- `python3 -m py_compile 'Native Instruments/script/device_setup/NILA_version_check.py'`


------
https://chatgpt.com/codex/tasks/task_e_6877c65016c08323a533adf77bc7211e