### PR TITLE
Fix spelling in buttons.py comment

### DIFF
--- a/Native Instruments/nihia/buttons.py
+++ b/Native Instruments/nihia/buttons.py
@@ -28,7 +28,7 @@ import nihia
 
 # Button name to button ID dictionary
 # The button ID is the number in hex that is used as the DATA1 parameter when a MIDI message related to that button is
-# sent or recieved from the device
+# sent or received from the device
 button_list = {
     "PLAY": 16,
     "RESTART": 17,


### PR DESCRIPTION
## Summary
- fix 'recieved' typo in `buttons.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877c64c532c832381a79b04b1ccefac