### PR TITLE
Fix typos and cleanup imports

### DIFF
--- a/Fruity NILA/NILA/NILA_visuals/NILA_LED.py
+++ b/Fruity NILA/NILA/NILA_visuals/NILA_LED.py
@@ -1,5 +1,4 @@
 import nihia
-from nihia import buttons
 from nihia.mixer import setTrackSolo, setTrackMute, setTrackArm
 from NILA.NILA_engine import constants
 import device

--- a/Fruity NILA/NILA/NILA_visuals/NILA_OLED.py
+++ b/Fruity NILA/NILA/NILA_visuals/NILA_OLED.py
@@ -198,7 +198,7 @@ def OnRefresh(self, event):
 					purge_all_tracks()
 		else:
 			track_index, mixer_slot = active_fx
-			full_plugin_name = plugins.getPluginName(track_index, mixer_slot)
+			full_plugin_name = plugins.getPluginName(track_index, mixer_slot) or "Unknown"
 			if "Fruity" in full_plugin_name:
 				full_plugin_name = full_plugin_name.replace("Fruity ", "")
 			plugin_name = (full_plugin_name[:9] if not NILA_core.seriesCheck() else full_plugin_name + "\n\n|Mix Level") \

--- a/Fruity NILA/device_Fruity NILA.py
+++ b/Fruity NILA/device_Fruity NILA.py
@@ -4,7 +4,7 @@
 # receiveFrom=Forward Device
 # supportedHardwareIds=00 33 09 96 24 32, 00 21 09 60 18 20
 
-import sys
+import logging
 
 import nihia
 import device
@@ -16,6 +16,8 @@ from NILA.NILA_engine import constants as c
 
 from NILA.NILA_UI import *
 from NILA.NILA_visuals import *
+
+logging.basicConfig(level=logging.ERROR)
 
 
 class Core:
@@ -136,7 +138,7 @@ class Core:
 			method_name (str): Name of the method where the exception occurred.
 			exception (Exception): The exception object.
 		"""
-		print(f"{method_name} error: {exception}\nException Type: {type(exception).__name__}\n")
+		logging.error(f"{method_name} error: {exception}\nException Type: {type(exception).__name__}\n")
 
 # Instantiate Core object
 n_Core = Core()

--- a/Fruity NILA/nihia/mixer.py
+++ b/Fruity NILA/nihia/mixer.py
@@ -74,7 +74,7 @@ mixerinfo_types = {
     # This one makes more sense on DAWs that create more tracks as the user requests it, as there might be projects (for example) on Ableton Live
     # with only two tracks
     # However, since FL Studio has all playlist and mixer tracks created, it has no use at all (maybe on the channel rack) and all tracks should have
-    # their existance reported as 1 (which means the track exists) in order to light on the Mute and Solo buttons on the device
+    # their existence reported as 1 (which means the track exists) in order to light on the Mute and Solo buttons on the device
     "EXIST": 64,
     "SELECTED": 66,
 
@@ -113,7 +113,7 @@ mixerinfo_types = {
 }
 
 # Track types dictionary
-# Used when reporting existance of tracks
+# Used when reporting existence of tracks
 track_types = {
     "EMPTY": 0,
     "GENERIC": 1,


### PR DESCRIPTION
## Summary
- remove unused import in LED visuals
- provide fallback plugin name text in OLED display
- log errors instead of printing
- fix typos in mixer comments
- add logging configuration

## Testing
- `python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_687bea8af3fc83238229e4e43c336b93